### PR TITLE
l2_interfaces set portmode depending on dictionary presence

### DIFF
--- a/plugins/module_utils/network/eos/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/eos/config/l2_interfaces/l2_interfaces.py
@@ -218,6 +218,12 @@ def set_interface(want, have):
     commands = []
 
     want_mode = want.get("mode")
+    if not want_mode:
+        if want.get("trunk"):
+            want_mode = "trunk"
+        elif want.get("access"):
+            want_mode = "access"
+
     if want_mode and want_mode != have.get("mode"):
         commands.append("switchport mode {0}".format(want_mode))
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The eos_l2_interfaces doesn't use the mode parameter which is used for setting switchport mode, this minor fix will check for presence of either the access or trunk dict and set mode to whatever it finds.

Fixes #14 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/module_utils/network/eos/config/l2_interfaces/l2_interfaces.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
